### PR TITLE
Use nonnegative-integer? in favor of natural-number?

### DIFF
--- a/brag/brag/brag.scrbl
+++ b/brag/brag/brag.scrbl
@@ -1041,10 +1041,10 @@ In addition to the exports shown below, the @racketmodname[brag/support] module 
 
 @defproc[(token [type (or/c string? symbol?)]
                 [val any/c #f]
-                [#:line line (or/c positive-integer? #f) #f]
-                [#:column column (or/c nonnegative-integer? #f) #f]
-                [#:position position (or/c positive-integer? #f) #f]
-                [#:span span (or/c nonnegative-integer? #f) #f]
+                [#:line line (or/c exact-positive-integer? #f) #f]
+                [#:column column (or/c exact-nonnegative-integer? #f) #f]
+                [#:position position (or/c exact-positive-integer? #f) #f]
+                [#:span span (or/c exact-nonnegative-integer? #f) #f]
                 [#:skip? skip? boolean? #f]
                 )
          token-struct?]{
@@ -1059,10 +1059,10 @@ In addition to the exports shown below, the @racketmodname[brag/support] module 
 
 @defstruct[token-struct ([type symbol?]
                          [val any/c]
-                         [position (or/c positive-integer? #f)]
-                         [line (or/c nonnegative-integer? #f)]
-                         [column (or/c positive-integer? #f)]
-                         [span (or/c nonnegative-integer? #f)]
+                         [position (or/c exact-positive-integer? #f)]
+                         [line (or/c exact-nonnegative-integer? #f)]
+                         [column (or/c exact-positive-integer? #f)]
+                         [span (or/c exact-nonnegative-integer? #f)]
                          [skip? boolean?])
            #:transparent]{
  The token structure type.

--- a/brag/brag/brag.scrbl
+++ b/brag/brag/brag.scrbl
@@ -1042,9 +1042,9 @@ In addition to the exports shown below, the @racketmodname[brag/support] module 
 @defproc[(token [type (or/c string? symbol?)]
                 [val any/c #f]
                 [#:line line (or/c positive-integer? #f) #f]
-                [#:column column (or/c natural-number? #f) #f]
+                [#:column column (or/c nonnegative-integer? #f) #f]
                 [#:position position (or/c positive-integer? #f) #f]
-                [#:span span (or/c natural-number? #f) #f]
+                [#:span span (or/c nonnegative-integer? #f) #f]
                 [#:skip? skip? boolean? #f]
                 )
          token-struct?]{
@@ -1060,9 +1060,9 @@ In addition to the exports shown below, the @racketmodname[brag/support] module 
 @defstruct[token-struct ([type symbol?]
                          [val any/c]
                          [position (or/c positive-integer? #f)]
-                         [line (or/c natural-number? #f)]
+                         [line (or/c nonnegative-integer? #f)]
                          [column (or/c positive-integer? #f)]
-                         [span (or/c natural-number? #f)]
+                         [span (or/c nonnegative-integer? #f)]
                          [skip? boolean?])
            #:transparent]{
  The token structure type.


### PR DESCRIPTION
The natural-number? predicate seems to be
unavailable (though there is a remnant of it in the form of
[`natural-number/c`](https://docs.racket-lang.org/reference/data-structure-contracts.html?q=nonnegative-integer%3F#%28def._%28%28lib._racket%2Fcontract%2Fprivate%2Fmisc..rkt%29._natural-number%2Fc%29%29), which is just a contract alias of
[`exact-nonnegative-integer?`](https://docs.racket-lang.org/reference/number-types.html?q=exact-nonnegative-integer%3F#%28def._%28%28quote._~23~25kernel%29._exact-nonnegative-integer~3f%29%29)). In any case, it surely means
nonnegative integer.

(One might push the envelope here slightly and add
exactness, but this commit does not go that far.)